### PR TITLE
Create AuthAdapter interface

### DIFF
--- a/src/main/java/com/cactus/adapters/AuthAdapter.java
+++ b/src/main/java/com/cactus/adapters/AuthAdapter.java
@@ -1,0 +1,45 @@
+package com.cactus.adapters;
+
+public interface AuthAdapter {
+
+    /**
+     * Returns a Response object with the results of a login operation done using the
+     * provided username and password.
+     *
+     * If the login was successful, the Response will have code 200 (OK), and a
+     * payload with the following keys:
+     * - userid
+     * - name
+     *
+     * If the login was unsuccessful, the Response will have code 400 (BAD_REQUEST)
+     * and a null payload.
+     *
+     * @param username a String containing the username of the user to be logged in
+     * @param password a String containing the password to validate
+     * @return         a Response to the login operation
+     *
+     * @see Response
+     */
+    public Response login(String username, String password);
+
+    /**
+     * Returns a Response object with the results of a create user operation done
+     * using the provided username, password, and name.
+     *
+     * If the user was created successfully, the Response will have code 200 (OK),
+     * and a payload with the following keys:
+     * - userid
+     * - name
+     *
+     * If the user creation was unsuccessful (i.e. username already exists), the
+     * Response will have code 400 (BAD_REQUEST) and a null payload.
+     *
+     * @param username a String containing the username of the new user
+     * @param password a String containing the password of the new user
+     * @param name     a String containing the name of the user
+     * @return         a Response to the create user operation
+     *
+     * @see Response
+     */
+    public Response create(String username, String password, String name);
+}

--- a/src/main/java/com/cactus/adapters/GroceryListManager.java
+++ b/src/main/java/com/cactus/adapters/GroceryListManager.java
@@ -1,4 +1,4 @@
-package com.cactus.managers;
+package com.cactus.adapters;
 
 import com.cactus.entities.GroceryItem;
 import com.cactus.entities.GroceryList;

--- a/src/main/java/com/cactus/adapters/Response.java
+++ b/src/main/java/com/cactus/adapters/Response.java
@@ -1,0 +1,45 @@
+package com.cactus.adapters;
+
+import java.util.HashMap;
+
+public class Response {
+
+    private final Status code;
+    private final HashMap<String, String> payload;
+
+    public enum Status {
+        OK (200),
+        NO_CONTENT (204),
+        BAD_REQUEST (400),
+        NOT_FOUND (404),
+        ERROR (500);
+
+        private int code;
+
+        Status(int code) {
+            this.code = code;
+        }
+
+        public int getCode() {
+            return code;
+        }
+    }
+
+    public Response(Status code) {
+        this.code = code;
+        this.payload = null;
+    }
+
+    public Response(Status code, HashMap<String, String> payload) {
+        this.code = code;
+        this.payload = payload;
+    }
+
+    public Status getStatusCode() {
+        return this.code;
+    }
+
+    public HashMap<String, String> getPayload() {
+        return this.payload;
+    }
+}

--- a/src/main/java/com/cactus/adapters/UserManager.java
+++ b/src/main/java/com/cactus/adapters/UserManager.java
@@ -1,4 +1,4 @@
-package com.cactus.managers;
+package com.cactus.adapters;
 
 import com.cactus.entities.User;
 

--- a/src/main/java/com/cactus/systems/GroceryListSystem.java
+++ b/src/main/java/com/cactus/systems/GroceryListSystem.java
@@ -1,11 +1,11 @@
 package com.cactus.systems;
 
-import com.cactus.managers.UserManager;
+import com.cactus.adapters.UserManager;
 import com.cactus.data.EntityRepository;
 import com.cactus.entities.GroceryItem;
 import com.cactus.entities.GroceryList;
 import com.cactus.entities.User;
-import com.cactus.managers.GroceryListManager;
+import com.cactus.adapters.GroceryListManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
The AuthAdapter interface serves as a boundary between the controller and the use case, and allows for the use of different concrete adapters as needed. It currently only specifies user creation and logging in; both operations will return a user id if successful. The user id should be used to authorize further requests, and logging out simply means not storing the user id anymore.

The Reponse object is simply a vessel that contain information returned by the use cases.