### PR TITLE
Return error when registering existing user

### DIFF
--- a/saguaro/src/main/java/com/saguaro/controller/UserController.java
+++ b/saguaro/src/main/java/com/saguaro/controller/UserController.java
@@ -5,8 +5,8 @@ import com.saguaro.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 public class UserController {
@@ -21,17 +21,24 @@ public class UserController {
     public User login(@RequestParam("username") String username, @RequestParam("password") String password) {
         User user = userService.login(username, password);
         if (user == null) {
-            throw new UsernameNotFoundException("Username/password invalid");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Username/password invalid");
         }
 
         return user;
     }
 
     @PostMapping("/register")
-    public User register(@RequestBody RegisterPayload payload){
-        return userService.registerNewUser(payload.getUsername(),
+    public User register(@RequestBody RegisterPayload payload) {
+        User user = userService.registerNewUser(payload.getUsername(),
                 payload.getPassword(),
                 payload.getName());
+
+        if (user == null) {
+            // TODO: create exception handler with better exceptions
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "User already exists");
+        }
+
+        return user;
     }
 
     private static class RegisterPayload {

--- a/saguaro/src/main/java/com/saguaro/repository/UserRepository.java
+++ b/saguaro/src/main/java/com/saguaro/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     User findUserByUsername(String username);
     User findUserByToken(String token);
+    boolean existsByUsername(String username);
 }

--- a/saguaro/src/main/java/com/saguaro/service/UserService.java
+++ b/saguaro/src/main/java/com/saguaro/service/UserService.java
@@ -44,6 +44,10 @@ public class UserService {
     }
 
     public User registerNewUser(String username, String password, String name) {
+        if (userRepository.existsByUsername(username)) {
+            return null;
+        }
+
         User newUser = new User();
         newUser.setUsername(username);
         newUser.setPassword(passwordEncoder.encode(password));


### PR DESCRIPTION
Previously, registering a user whose username already exists in the database was allowed. This change will return a 400 BAD_REQUEST error when this operation is attempted.