### PR TITLE
Fix role insert bug

### DIFF
--- a/saguaro/src/main/resources/data.sql
+++ b/saguaro/src/main/resources/data.sql
@@ -1,2 +1,6 @@
-INSERT INTO role (id, name)
-VALUES (0, 'ROLE_USER');
+INSERT INTO role
+SELECT *
+FROM (
+         SELECT 0, 'ROLE_USER'
+     ) x
+WHERE NOT EXISTS(SELECT * FROM role WHERE id = 0);


### PR DESCRIPTION
Fixes a bug where a restart of a server would cause database initialization to fail, since the database initialization script would be trying to insert a role that had already been inserted by the previous server run, causing a primary key conflict.