### PR TITLE
Add functionality to edit grocery list names and user profiles

### DIFF
--- a/saguaro/src/main/java/com/saguaro/controller/GroceryController.java
+++ b/saguaro/src/main/java/com/saguaro/controller/GroceryController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.constraints.NotBlank;
 import java.util.Map;
 
 /**
@@ -25,6 +26,7 @@ import java.util.Map;
  * @author Charles Wong
  */
 @RestController
+@Validated
 public class GroceryController {
 
     /**
@@ -105,13 +107,13 @@ public class GroceryController {
      * Given some valid GroceryList object, saves the object as the new state of the
      * list. The grocery list to be overwritten is identified by the list ID. The
      * name attribute may be null, in which case the list's name will remain unchanged.
-     *
+     * <p>
      * If the provided list has an ID which does not exist, or the ID corresponds to a
      * list that does not belong to the currently authenticated user, a
      * ResourceNotFoundException is thrown.
-     *
+     * <p>
      * If the save is successful, then the newly saved grocery list is returned.
-     *
+     * <p>
      * Since this endpoint is a protected resource, a valid username must
      * be available from the SecurityContext when this method is invoked.
      *
@@ -125,6 +127,30 @@ public class GroceryController {
         String username = (String) auth.getPrincipal();
 
         return groceryService.saveList(list, username);
+    }
+
+    /**
+     * Edit the name of some existing grocery list. The grocery list to edit is specified by a long representing
+     * an ID, and a non-blank new name must be provided.
+     * <p>
+     * If the provided list ID does not match any grocery list belonging to the currently authenticated user,
+     * a ResourceNotFoundException is thrown.
+     * <p>
+     * If the edit is successful, the newly modified grocery list is returned.
+     *
+     * @param name the String to set the list name to
+     * @param id   a long representing the ID of the grocery list to edit
+     * @return the newly modified GroceryList
+     * @throws ResourceNotFoundException if the provided list ID does not match any grocery list belonging to
+     *                                   the currently authenticated user
+     */
+    @PutMapping("api/edit-list-name")
+    public GroceryList editListName(@RequestParam("name") @NotBlank String name, @RequestParam("id") long id)
+            throws ResourceNotFoundException {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = (String) auth.getPrincipal();
+
+        return groceryService.editListName(id, name, username);
     }
 
     /**

--- a/saguaro/src/main/java/com/saguaro/controller/NullOrNotBlank.java
+++ b/saguaro/src/main/java/com/saguaro/controller/NullOrNotBlank.java
@@ -1,0 +1,20 @@
+package com.saguaro.controller;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ElementType.FIELD})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = NullOrNotBlankValidator.class)
+public @interface NullOrNotBlank {
+    String message() default "{javax.validation.constraints.NullOrNotBlank.message}";
+    Class<?>[] groups() default { };
+    Class<? extends Payload>[] payload() default {};
+}

--- a/saguaro/src/main/java/com/saguaro/controller/NullOrNotBlankValidator.java
+++ b/saguaro/src/main/java/com/saguaro/controller/NullOrNotBlankValidator.java
@@ -1,0 +1,14 @@
+package com.saguaro.controller;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NullOrNotBlankValidator implements ConstraintValidator<NullOrNotBlank, String> {
+
+    public void initialize(NullOrNotBlank parameters) {
+    }
+
+    public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+        return value == null || value.trim().length() > 0;
+    }
+}

--- a/saguaro/src/main/java/com/saguaro/controller/UserController.java
+++ b/saguaro/src/main/java/com/saguaro/controller/UserController.java
@@ -51,7 +51,7 @@ public class UserController {
      * @param payload the UserPayload containing user attributes to change
      * @return the newly saved User object
      */
-    @PostMapping("/api/edit-user")
+    @PutMapping("/api/edit-user")
     public User editUser(@Validated(EditGroup.class) @RequestBody UserPayload payload) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String username = (String) auth.getPrincipal();

--- a/saguaro/src/main/java/com/saguaro/controller/UserController.java
+++ b/saguaro/src/main/java/com/saguaro/controller/UserController.java
@@ -11,7 +11,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.groups.Default;
 
 @RestController
 public class UserController {

--- a/saguaro/src/main/java/com/saguaro/controller/UserController.java
+++ b/saguaro/src/main/java/com/saguaro/controller/UserController.java
@@ -28,13 +28,38 @@ public class UserController {
     }
 
     @PostMapping("/register")
-    public User register(@Validated @RequestBody RegisterPayload payload) throws InvalidParamException {
+    public User register(@Validated @RequestBody UserPayload payload) throws InvalidParamException {
         return userService.registerNewUser(payload.username,
                 payload.password,
                 payload.name);
     }
 
-    private static class RegisterPayload {
+    @PostMapping("/logout")
+    @ResponseStatus(value = HttpStatus.NO_CONTENT)
+    public void logout() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = (String) auth.getPrincipal();
+
+        userService.logout(username);
+    }
+
+    /**
+     * Given a UserPayload, replaced the logged-in user's attributes with any non-null
+     * attributes of the payload. Note that a user's username cannot be changed; the
+     * username property of the payload is ignored by this method.
+     *
+     * @param payload the UserPayload containing user attributes to change
+     * @return the newly saved User object
+     */
+    @PostMapping("/api/edit-user")
+    public User editUser(@RequestBody UserPayload payload) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = (String) auth.getPrincipal();
+
+        return userService.edit(payload.name, payload.password, username);
+    }
+
+    private static class UserPayload {
         @NotBlank
         String name;
 
@@ -55,14 +80,5 @@ public class UserController {
         public void setPassword(String password) {
             this.password = password;
         }
-    }
-
-    @PostMapping("/logout")
-    @ResponseStatus(value = HttpStatus.NO_CONTENT)
-    public void logout() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String username = (String) auth.getPrincipal();
-
-        userService.logout(username);
     }
 }

--- a/saguaro/src/main/java/com/saguaro/service/GroceryService.java
+++ b/saguaro/src/main/java/com/saguaro/service/GroceryService.java
@@ -66,6 +66,10 @@ public class GroceryService {
                     String.valueOf(list.getId()), user);
         }
 
+        if (list.getName() != null) {
+            oldList.setName(list.getName());
+        }
+
         HashSet<GroceryItem> foundItems = new HashSet<>();
 
         for (GroceryItem item : list.getItems()) {

--- a/saguaro/src/main/java/com/saguaro/service/GroceryService.java
+++ b/saguaro/src/main/java/com/saguaro/service/GroceryService.java
@@ -7,8 +7,8 @@ import com.saguaro.exception.ResourceNotFoundException;
 import com.saguaro.repository.GroceryItemRepository;
 import com.saguaro.repository.GroceryListRepository;
 import com.saguaro.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -16,16 +16,22 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional(readOnly = true)
 public class GroceryService {
 
-    @Autowired
     UserRepository userRepository;
 
-    @Autowired
     GroceryListRepository groceryListRepository;
 
-    @Autowired
     GroceryItemRepository groceryItemRepository;
+
+    public GroceryService (UserRepository userRepository,
+                           GroceryListRepository groceryListRepository,
+                           GroceryItemRepository groceryItemRepository) {
+        this.userRepository = userRepository;
+        this.groceryListRepository = groceryListRepository;
+        this.groceryItemRepository = groceryItemRepository;
+    }
 
     public Map<Long, String> getListNamesByUsername(String username) {
         User user = userRepository.findUserByUsername(username);
@@ -47,6 +53,7 @@ public class GroceryService {
         return list;
     }
 
+    @Transactional
     public GroceryList createNewList(String name, String username) {
         User user = userRepository.findUserByUsername(username);
 
@@ -57,6 +64,7 @@ public class GroceryService {
         return groceryListRepository.save(list);
     }
 
+    @Transactional
     public GroceryList saveList(GroceryList list, String username) throws ResourceNotFoundException {
         User user = userRepository.findUserByUsername(username);
         GroceryList oldList = groceryListRepository.findGroceryListById(list.getId());
@@ -90,6 +98,7 @@ public class GroceryService {
         return groceryListRepository.save(oldList);
     }
 
+    @Transactional
     public void removeList(long id, String username) throws ResourceNotFoundException {
         User user = userRepository.findUserByUsername(username);
         GroceryList list = groceryListRepository.findGroceryListById(id);

--- a/saguaro/src/main/java/com/saguaro/service/GroceryService.java
+++ b/saguaro/src/main/java/com/saguaro/service/GroceryService.java
@@ -99,7 +99,8 @@ public class GroceryService {
     }
 
     /**
-     * Set an existing grocery list's name to some new string.
+     * Set an existing grocery list's name to some new string. This method assumes that the username
+     * provided must be valid, since a user must be authenticated in order to edit a list's name.
      * <p>
      * A ResourceNotFoundException is found in the case where the provided list ID does not match
      * any grocery list belonging to the user with the provided username.

--- a/saguaro/src/main/java/com/saguaro/service/GroceryService.java
+++ b/saguaro/src/main/java/com/saguaro/service/GroceryService.java
@@ -25,9 +25,9 @@ public class GroceryService {
 
     GroceryItemRepository groceryItemRepository;
 
-    public GroceryService (UserRepository userRepository,
-                           GroceryListRepository groceryListRepository,
-                           GroceryItemRepository groceryItemRepository) {
+    public GroceryService(UserRepository userRepository,
+                          GroceryListRepository groceryListRepository,
+                          GroceryItemRepository groceryItemRepository) {
         this.userRepository = userRepository;
         this.groceryListRepository = groceryListRepository;
         this.groceryItemRepository = groceryItemRepository;
@@ -96,6 +96,34 @@ public class GroceryService {
         }
 
         return groceryListRepository.save(oldList);
+    }
+
+    /**
+     * Set an existing grocery list's name to some new string.
+     * <p>
+     * A ResourceNotFoundException is found in the case where the provided list ID does not match
+     * any grocery list belonging to the user with the provided username.
+     * <p>
+     * If the edit is successful, then the newly modified GroceryList is returned.
+     *
+     * @param listId   a long representing the ID of the grocery list to edit
+     * @param newName  the String to set the name of the grocery list to
+     * @param username the username of the user making the edit
+     * @return the newly modified GroceryList object
+     * @throws ResourceNotFoundException if the provided list ID does not match any grocery list belonging
+     *                                   to the user with the provided username
+     */
+    @Transactional
+    public GroceryList editListName(long listId, String newName, String username) throws ResourceNotFoundException {
+        User user = userRepository.findUserByUsername(username);
+        GroceryList list = groceryListRepository.findGroceryListById(listId);
+
+        if (list == null || list.getUser() != user) {
+            throw new ResourceNotFoundException(GroceryList.class, String.valueOf(listId), user);
+        }
+
+        list.setName(newName);
+        return groceryListRepository.save(list);
     }
 
     @Transactional

--- a/saguaro/src/main/java/com/saguaro/service/UserService.java
+++ b/saguaro/src/main/java/com/saguaro/service/UserService.java
@@ -6,28 +6,33 @@ import com.saguaro.exception.InvalidLoginException;
 import com.saguaro.exception.InvalidParamException;
 import com.saguaro.repository.RoleRepository;
 import com.saguaro.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.UUID;
 
 @Service
+@Transactional(readOnly = true)
 public class UserService {
 
-    @Autowired
     UserRepository userRepository;
 
-    @Autowired
     RoleRepository roleRepository;
 
-    @Autowired
     PasswordEncoder passwordEncoder;
 
+    public UserService(UserRepository userRepository,
+                       RoleRepository roleRepository,
+                       PasswordEncoder passwordEncoder) {
+
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
     public User login(String username, String password) throws InvalidLoginException {
         User user = userRepository.findUserByUsername(username);
 
@@ -43,12 +48,14 @@ public class UserService {
         throw new InvalidLoginException();
     }
 
+    @Transactional
     public void logout(String username) {
         User user = userRepository.findUserByUsername(username);
         user.setToken(null);
         userRepository.save(user);
     }
 
+    @Transactional
     public User registerNewUser(String username, String password, String name)
             throws InvalidParamException {
         if (userRepository.existsByUsername(username)) {
@@ -66,7 +73,6 @@ public class UserService {
         return userRepository.save(newUser);
     }
 
-    @Transactional(readOnly = true)
     public UserDetails findByToken(String token) {
         User user = userRepository.findUserByToken(token);
 
@@ -74,14 +80,45 @@ public class UserService {
             return null;
         }
 
-        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
-
-        return buildSpringUser(user, authorities); // roles are loaded lazily, so fetch them here for use
+        return buildSpringUser(user);
     }
 
-    private org.springframework.security.core.userdetails.User buildSpringUser(User user, Collection<? extends GrantedAuthority> authorities) {
+    private org.springframework.security.core.userdetails.User buildSpringUser(User user) {
         return new org.springframework.security.core.userdetails.User(
-                user.getUsername(), user.getToken(), true, true, true, true, authorities
+                user.getUsername(),
+                user.getToken(),
+                true,
+                true,
+                true,
+                true,
+                user.getAuthorities()
         );
+    }
+
+    /**
+     * Edits the name and password of a User, specified by a username. The name
+     * or password can be null, in which case that attribute of the user remains
+     * unchanged.
+     *
+     * The plaintext password is hashed using bcrypt, and then saved.
+     *
+     * @param name the String name to replace, if not null
+     * @param password the String plaintext of the password to replace, if not null
+     * @param username the String username of the user to change the attributes of
+     * @return the newly saved User object
+     */
+    @Transactional
+    public User edit(String name, String password, String username) {
+        User user = userRepository.findUserByUsername(username);
+
+        if (name != null) {
+            user.setName(name);
+        }
+
+        if (password != null) {
+            user.setPassword(passwordEncoder.encode(password));
+        }
+
+        return userRepository.save(user);
     }
 }

--- a/saguaro/src/test/java/com/saguaro/controller/GroceryControllerTest.java
+++ b/saguaro/src/test/java/com/saguaro/controller/GroceryControllerTest.java
@@ -198,7 +198,7 @@ class GroceryControllerTest {
         }
 
         @Test
-        void testSaveListBlankItem() throws Exception {
+        void testSaveListBadRequestBlankItem() throws Exception {
             HashMap<String, String> bad = new HashMap<>();
             bad.put("iid", "1");
             bad.put("items", "[\" \", \"b\"]");

--- a/saguaro/src/test/java/com/saguaro/controller/GroceryControllerTest.java
+++ b/saguaro/src/test/java/com/saguaro/controller/GroceryControllerTest.java
@@ -211,6 +211,42 @@ class GroceryControllerTest {
     }
 
     @Nested
+    class EditListNameTest {
+
+        @Test
+        void testEditListNameValid() throws Exception {
+            GroceryList list = new GroceryList();
+            when(groceryService.editListName(anyLong(), anyString(), anyString())).thenReturn(list);
+
+            mvc.perform(put("/api/edit-list-name")
+                            .queryParam("id", "4")
+                            .queryParam("name", "name"))
+                    .andExpect(status().isOk())
+                    .andExpect(result -> assertEquals(jsonGroceryList.write(list).getJson(), result.getResponse().getContentAsString()));
+        }
+
+        @Test
+        void testEditListNameNotFound() throws Exception {
+            when(groceryService.editListName(anyLong(), anyString(), anyString())).thenThrow(ResourceNotFoundException.class);
+
+            mvc.perform(put("/api/edit-list-name")
+                            .queryParam("id", "4")
+                            .queryParam("name", "name"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(result -> assertTrue(result.getResolvedException() instanceof
+                            ResourceNotFoundException));
+        }
+
+        @Test
+        void testEditListNameBlankName() throws Exception {
+            mvc.perform(put("/api/save-list")
+                            .queryParam("list", "4")
+                            .queryParam("name", ""))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
     class DeleteListTest {
 
         @Test

--- a/saguaro/src/test/java/com/saguaro/controller/UserControllerTest.java
+++ b/saguaro/src/test/java/com/saguaro/controller/UserControllerTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -228,7 +229,7 @@ class UserControllerTest {
             when(userService.edit("name", "password", "username"))
                     .thenReturn(user);
 
-            mvc.perform(post("/api/edit-user")
+            mvc.perform(put("/api/edit-user")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{\"password\":\"password\"" +
                                     ",\"name\":\"name\"}")
@@ -246,7 +247,7 @@ class UserControllerTest {
             when(userService.edit("name", "password", "username"))
                     .thenReturn(user);
 
-            mvc.perform(post("/api/edit-user")
+            mvc.perform(put("/api/edit-user")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{\"username\":\"username\"" +
                                     ",\"password\":\"password\"" +
@@ -265,7 +266,7 @@ class UserControllerTest {
             when(userService.edit(null, null, "username"))
                     .thenReturn(user);
 
-            mvc.perform(post("/api/edit-user")
+            mvc.perform(put("/api/edit-user")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{}")
                             .header("Authentication", "token")
@@ -276,7 +277,7 @@ class UserControllerTest {
 
         @Test
         void testEditUserBadRequestBlankName() throws Exception {
-            mvc.perform(post("/api/edit-user")
+            mvc.perform(put("/api/edit-user")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{\"password\":\"password\"" +
                             ",\"name\":\"\"}")
@@ -286,7 +287,7 @@ class UserControllerTest {
 
         @Test
         void testEditUserBadRequestBlankPassword() throws Exception {
-            mvc.perform(post("/api/edit-user")
+            mvc.perform(put("/api/edit-user")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{\"password\":\" \"" +
                             ",\"name\":\"name\"}")

--- a/saguaro/src/test/java/com/saguaro/service/GroceryServiceTest.java
+++ b/saguaro/src/test/java/com/saguaro/service/GroceryServiceTest.java
@@ -236,6 +236,45 @@ class GroceryServiceTest {
         }
 
         @Test
+        void testSaveListNameUnchanged() throws Exception {
+            GroceryList existingList = new GroceryList();
+            existingList.setName("name");
+            existingList.setUser(user);
+
+            GroceryList newList = new GroceryList();
+            newList.setUser(user);
+            ReflectionTestUtils.setField(newList, "id", 1L);
+
+            when(groceryListRepository.save(any(GroceryList.class))).thenAnswer(ans -> ans.getArgument(0));
+            when(groceryListRepository.findGroceryListById(1L)).thenReturn(existingList);
+
+            GroceryList actual = groceryService.saveList(newList, "username");
+
+            verify(groceryListRepository, times(1)).save(existingList);
+            assertEquals("name", actual.getName());
+        }
+
+        @Test
+        void testSaveListNameChanged() throws Exception {
+            GroceryList existingList = new GroceryList();
+            existingList.setName("name");
+            existingList.setUser(user);
+
+            GroceryList newList = new GroceryList();
+            newList.setName("new");
+            newList.setUser(user);
+            ReflectionTestUtils.setField(newList, "id", 1L);
+
+            when(groceryListRepository.save(any(GroceryList.class))).thenAnswer(ans -> ans.getArgument(0));
+            when(groceryListRepository.findGroceryListById(1L)).thenReturn(existingList);
+
+            GroceryList actual = groceryService.saveList(newList, "username");
+
+            verify(groceryListRepository, times(1)).save(existingList);
+            assertEquals("new", actual.getName());
+        }
+
+        @Test
         void testSaveListInvalidId() {
             when(groceryListRepository.findGroceryListById(anyLong())).thenReturn(null);
 

--- a/saguaro/src/test/java/com/saguaro/service/UserServiceTest.java
+++ b/saguaro/src/test/java/com/saguaro/service/UserServiceTest.java
@@ -193,4 +193,34 @@ class UserServiceTest {
             assertNull(actual);
         }
     }
+
+    @Nested
+    class EditTest {
+
+        @BeforeEach
+        void setUpEdit() {
+            when(userRepository.findUserByUsername(username)).thenReturn(user);
+            when(userRepository.save(any(User.class))).thenAnswer(ans -> ans.getArgument(0));
+        }
+
+        @Test
+        void testEditNameAndPassword() {
+            when(passwordEncoder.encode("NEW_PASS")).thenReturn("HASH");
+
+            User actual = userService.edit("NEW_NAME", "NEW_PASS", username);
+
+            assertEquals("NEW_NAME", actual.getName());
+            assertEquals("HASH", actual.getPassword());
+            assertEquals(username, actual.getUsername());
+        }
+
+        @Test
+        void testEditNoChange() {
+            User actual = userService.edit(null, null, username);
+
+            assertEquals(name, actual.getName());
+            assertEquals(password, actual.getPassword());
+            assertEquals(username, actual.getUsername());
+        }
+    }
 }


### PR DESCRIPTION
Adding a non-blank `name` property to the `api/save-list` request body will now overwrite the existing list name with that value.

Added an endpoint `api/edit-user` which allows you to specify two optional request body properties &mdash; `password` and `name` &mdash; to change. If provided, these values must contain at least one non-whitespace character. The username of a user cannot be changed once registered. If successful, the new User object is returned as JSON.