### PR TITLE
Fix Cereus networking

### DIFF
--- a/cereus/src/main/java/com/cactus/adapters/WebAuthAdapter.java
+++ b/cereus/src/main/java/com/cactus/adapters/WebAuthAdapter.java
@@ -35,7 +35,8 @@ public class WebAuthAdapter implements AuthAdapter {
         String tempIp = "192.168.0.127"; // default to this address
 
         try {
-            InputStream input = new FileInputStream("src/main/resources/network.properties");
+            ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+            InputStream input = classloader.getResourceAsStream("network.properties");
 
             Properties props = new Properties();
             props.load(input);
@@ -197,6 +198,7 @@ public class WebAuthAdapter implements AuthAdapter {
 
         Request request = new Request.Builder()
                 .url(url)
+                .post(RequestBody.create("", null))
                 .addHeader("Authorization", token)
                 .build();
 

--- a/cereus/src/main/java/com/cactus/adapters/WebAuthAdapter.java
+++ b/cereus/src/main/java/com/cactus/adapters/WebAuthAdapter.java
@@ -8,7 +8,6 @@ import okhttp3.*;
 import okhttp3.Response;
 
 import javax.inject.Inject;
-import java.io.FileInputStream;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/cereus/src/main/java/com/cactus/adapters/WebGroceryAdapter.java
+++ b/cereus/src/main/java/com/cactus/adapters/WebGroceryAdapter.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import okhttp3.*;
 
 import javax.inject.Inject;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;

--- a/cereus/src/main/java/com/cactus/adapters/WebGroceryAdapter.java
+++ b/cereus/src/main/java/com/cactus/adapters/WebGroceryAdapter.java
@@ -31,7 +31,8 @@ public class WebGroceryAdapter implements GroceryAdapter {
     public WebGroceryAdapter() {
         String tempIp = "192.168.0.127"; // default to this address
         try {
-            InputStream input = new FileInputStream("src/main/resources/network.properties");
+            ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+            InputStream input = classloader.getResourceAsStream("network.properties");
 
             Properties props = new Properties();
             props.load(input);

--- a/cereus/src/main/java/com/cactus/ui/MainActivity.java
+++ b/cereus/src/main/java/com/cactus/ui/MainActivity.java
@@ -1,6 +1,7 @@
 package com.cactus.ui;
 
 import android.content.Intent;
+import android.os.StrictMode;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
@@ -31,6 +32,11 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         setTitle("Cereus App : Login");
+
+        // needs to be set before any networking is done
+        // since the entry point to the app will pretty much always be here, set this here
+        StrictMode.ThreadPolicy policy = new StrictMode.ThreadPolicy.Builder().permitAll().build();
+        StrictMode.setThreadPolicy(policy);
 
         displayOptions();
     }

--- a/cereus/src/main/java/com/cactus/ui/SignupActivity.java
+++ b/cereus/src/main/java/com/cactus/ui/SignupActivity.java
@@ -34,9 +34,6 @@ public class SignupActivity extends AppCompatActivity {
 
         setTitle("Cereus App : Signup");
 
-        StrictMode.ThreadPolicy policy = new StrictMode.ThreadPolicy.Builder().permitAll().build();
-        StrictMode.setThreadPolicy(policy);
-
         displayOptions();
     }
 


### PR DESCRIPTION
Fixes:
- `network.properties` wasn't being read correctly, since the working directory of the running app is on the emulator, so FileIO does not have access to resources folder
- Since networking on the main thread is enabled globally, it should be enabled on first entry into the app. Trying to log in without first signing up would cause the main thread networking error, since this setting was only being enabled on navigation to the sign up activity.
- logout is a POST method, it was being called as a GET method