### PR TITLE
Fix input stream null bug

### DIFF
--- a/cereus/src/main/java/com/cactus/adapters/WebAuthAdapter.java
+++ b/cereus/src/main/java/com/cactus/adapters/WebAuthAdapter.java
@@ -37,7 +37,7 @@ public class WebAuthAdapter implements AuthAdapter {
             ClassLoader classloader = Thread.currentThread().getContextClassLoader();
             InputStream input = classloader.getResourceAsStream("network.properties");
 
-            if (input != null){
+            if (input != null) {
                 Properties props = new Properties();
                 props.load(input);
 

--- a/cereus/src/main/java/com/cactus/adapters/WebAuthAdapter.java
+++ b/cereus/src/main/java/com/cactus/adapters/WebAuthAdapter.java
@@ -37,10 +37,12 @@ public class WebAuthAdapter implements AuthAdapter {
             ClassLoader classloader = Thread.currentThread().getContextClassLoader();
             InputStream input = classloader.getResourceAsStream("network.properties");
 
-            Properties props = new Properties();
-            props.load(input);
+            if (input != null){
+                Properties props = new Properties();
+                props.load(input);
 
-            tempIp = props.getProperty("staticIp");
+                tempIp = props.getProperty("staticIp");
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/cereus/src/main/java/com/cactus/adapters/WebGroceryAdapter.java
+++ b/cereus/src/main/java/com/cactus/adapters/WebGroceryAdapter.java
@@ -33,10 +33,12 @@ public class WebGroceryAdapter implements GroceryAdapter {
             ClassLoader classloader = Thread.currentThread().getContextClassLoader();
             InputStream input = classloader.getResourceAsStream("network.properties");
 
-            Properties props = new Properties();
-            props.load(input);
+            if (input != null){
+                Properties props = new Properties();
+                props.load(input);
 
-            tempIp = props.getProperty("staticIp");
+                tempIp = props.getProperty("staticIp");
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/cereus/src/main/java/com/cactus/adapters/WebGroceryAdapter.java
+++ b/cereus/src/main/java/com/cactus/adapters/WebGroceryAdapter.java
@@ -33,7 +33,7 @@ public class WebGroceryAdapter implements GroceryAdapter {
             ClassLoader classloader = Thread.currentThread().getContextClassLoader();
             InputStream input = classloader.getResourceAsStream("network.properties");
 
-            if (input != null){
+            if (input != null) {
                 Properties props = new Properties();
                 props.load(input);
 
@@ -51,11 +51,10 @@ public class WebGroceryAdapter implements GroceryAdapter {
     /**
      * Returns a List of GroceryList objects that correspond to the User associated with the given token
      * <p>
-     *
+     * <p>
      * The token is sent to the server to return the list of grocery lists, which returns the names and ids.
-     *
+     * <p>
      * The id of each list is used to get every grocery list using getGroceryList().
-     *
      *
      * @param token a string representing the user token to fetch lists for
      * @return a List of GroceryList objects that are of the User whose token is entered
@@ -109,7 +108,7 @@ public class WebGroceryAdapter implements GroceryAdapter {
      * A user token is required for authorization.
      * <p>
      * The token and listID are sent to the server to return the GroceryList.
-     *
+     * <p>
      * If the listID does not correspond to an existing list, then null is returned.
      *
      * @param listID a long representing the ID of the list to get
@@ -149,9 +148,9 @@ public class WebGroceryAdapter implements GroceryAdapter {
 
     /**
      * Returns a list of GroceryItem objects that belong to the given list
-     *
+     * <p>
      * The token and listID are sent to the server to return the list of Grocery Items.
-     *
+     * <p>
      * If the listID does not correspond to an existing list, then null is returned.
      *
      * @param listID id of the list which holds the items you are getting
@@ -208,9 +207,9 @@ public class WebGroceryAdapter implements GroceryAdapter {
 
     /**
      * Returns a GroceryList with the name given. A user token is required for authorization.
-     *
+     * <p>
      * nameList and token are sent to the server to create a GroceryList.
-     *
+     * <p>
      * If the token does not correspond to the User, null is returned.
      *
      * @param nameList a String containing the name of the new grocery list
@@ -260,7 +259,7 @@ public class WebGroceryAdapter implements GroceryAdapter {
     /**
      * Returns whether the list of grocery items are added to the GroceryList that corresponds
      * to the listID given. A user token is required for authorization.
-     *
+     * <p>
      * The items, listID and token are sent to the server to append items to the list corresponding to
      * listID.
      *
@@ -304,9 +303,8 @@ public class WebGroceryAdapter implements GroceryAdapter {
     /**
      * Returns whether the GroceryList corresponding to the listID is deleted.
      * A user token is required for authorization.
-     *
-     *The listID and token are sent to the server to delete the list corresponding to listID.
-     *
+     * <p>
+     * The listID and token are sent to the server to delete the list corresponding to listID.
      *
      * @param listID a long representing the ID of the grocery list to delete
      * @param token  a string representing the token of the grocery list's owner


### PR DESCRIPTION
Fixed bug where if `network.properties` does not exist, the input stream used to read it would be null and a runtime exception would be thrown.