### PR TITLE
Add option to initialize grocery list with template

### DIFF
--- a/saguaro/src/main/java/com/saguaro/controller/GroceryController.java
+++ b/saguaro/src/main/java/com/saguaro/controller/GroceryController.java
@@ -85,7 +85,13 @@ public class GroceryController {
     }
 
     /**
-     * Create a new grocery list with the given name. Returns a GroceryList object,
+     * Create a new grocery list with the given name. Optionally mark the grocery list as
+     * a template, or initialize the grocery list with the items from an existing template. Note that
+     * these are mutually exclusive, with marking as template having precedence: if a grocery list is marked
+     * as a template, it will not be initialized with an existing template, regardless of if that argument is
+     * provided.
+     * <p>
+     * Returns a GroceryList object,
      * which in this context is simply a vehicle for the following information:
      * <ul>
      *      <li>list ID
@@ -98,9 +104,17 @@ public class GroceryController {
      */
     @PostMapping("api/create-list")
     public GroceryList createNewList(@RequestParam("name") String name,
-                                     @RequestParam(value = "template", required = false, defaultValue = "false") boolean template) {
+                                     @RequestParam(value = "template", required = false, defaultValue = "false") boolean template,
+                                     @RequestParam(value = "templateId", required = false) Long templateId)
+            throws ResourceNotFoundException {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String username = (String) auth.getPrincipal();
+
+        if (template) {
+            return groceryService.createNewList(name, username, template);
+        } else if (templateId != null) {
+            return groceryService.createNewList(name, username, templateId);
+        }
 
         return groceryService.createNewList(name, username, template);
     }

--- a/saguaro/src/main/java/com/saguaro/service/GroceryService.java
+++ b/saguaro/src/main/java/com/saguaro/service/GroceryService.java
@@ -158,7 +158,7 @@ public class GroceryService {
         User user = userRepository.findUserByUsername(username);
         GroceryList template = groceryListRepository.findGroceryListById(templateId);
 
-        if (template == null || !template.isTemplate() || template.getOwner() != user) {
+        if (template == null || !template.isTemplate() || !user.equals(template.getOwner())) {
             throw new ResourceNotFoundException("Could not find GroceryList template " + templateId + " for user " + user.getUsername());
         }
 

--- a/saguaro/src/main/java/com/saguaro/service/GroceryService.java
+++ b/saguaro/src/main/java/com/saguaro/service/GroceryService.java
@@ -118,6 +118,15 @@ public class GroceryService {
         return list;
     }
 
+    /**
+     * Create a new grocery list with the provided name, for the user specified by username. Additionally mark
+     * this grocery list as being a template or not.
+     *
+     * @param name a String to initialize the new GroceryList's name with
+     * @param username the String username of the user to create this list for
+     * @param template a boolean specifying whether this grocery list should be a template
+     * @return the newly saved GroceryList object
+     */
     @Transactional
     public GroceryList createNewList(String name, String username, boolean template) {
         User user = userRepository.findUserByUsername(username);
@@ -126,6 +135,39 @@ public class GroceryService {
         list.setName(name);
         list.setOwner(user);
         list.setTemplate(template);
+
+        return groceryListRepository.save(list);
+    }
+
+    /**
+     * Create a new grocery list with the provided name, for the user specified by username.
+     * Additionally initialize this grocery list with the items from a template. If the
+     * template does not exist, a ResourceNotFoundException is thrown.
+     *
+     * Note that a grocery list cannot have been marked as a template if it is being initalized with a template.
+     *
+     * @param name a String to initialize the new GroceryList's name with
+     * @param username the String username of the user to create this list for
+     * @param templateId a long representing the ID of the template to initialize this grocery list with
+     * @return the newly saved GroceryList object
+     * @throws ResourceNotFoundException if the provided template id to initialize this grocery list with does not
+     *                                   exist
+     */
+    @Transactional
+    public GroceryList createNewList(String name, String username, long templateId) throws ResourceNotFoundException {
+        User user = userRepository.findUserByUsername(username);
+        GroceryList template = groceryListRepository.findGroceryListById(templateId);
+
+        if (template == null || !template.isTemplate() || template.getOwner() != user) {
+            throw new ResourceNotFoundException("Could not find GroceryList template " + templateId + " for user " + user.getUsername());
+        }
+
+        GroceryList list = new GroceryList();
+        list.setName(name);
+        list.setOwner(user);
+        list.setTemplate(false);
+
+        this.mergeLists(list, template);
 
         return groceryListRepository.save(list);
     }
@@ -144,9 +186,26 @@ public class GroceryService {
             oldList.setName(list.getName());
         }
 
+        this.mergeLists(oldList, list);
+
+        return groceryListRepository.save(oldList);
+    }
+
+
+    /**
+     * Given an old grocery list and a new grocery list, replace the items in the old grocery list with
+     * items from the new. Crucially, if an item with the same name (which translates to the same item, in this
+     * application) exists in both lists, then the item in the old list should not be overwritten with a new instance.
+     * Additionally, if an item needs to be added to the old list from the new list, and that item already exists
+     * in the database, then that is the instance that should be saved to the list (do not duplicate existing items).
+     *
+     * @param oldList the GroceryList to save a new state to
+     * @param newList a GroceryList that the old list's state to be modified to mirror
+     */
+    private void mergeLists(GroceryList oldList, GroceryList newList) {
         HashSet<GroceryItem> foundItems = new HashSet<>();
 
-        for (GroceryItem item : list.getItems()) {
+        for (GroceryItem item : newList.getItems()) {
             if (!oldList.getItems().contains(item)) {
                 GroceryItem savedItem = groceryItemRepository.findGroceryItemByName(item.getName());
                 oldList.addItem(Objects.requireNonNullElse(savedItem, item));
@@ -160,8 +219,6 @@ public class GroceryService {
                 oldList.removeItem(oldList.getItems().get(i));
             }
         }
-
-        return groceryListRepository.save(oldList);
     }
 
     /**

--- a/saguaro/src/test/java/com/saguaro/controller/GroceryControllerTest.java
+++ b/saguaro/src/test/java/com/saguaro/controller/GroceryControllerTest.java
@@ -142,9 +142,42 @@ class GroceryControllerTest {
 
             mvc.perform(post("/api/create-list")
                             .queryParam("name", "name")
-                            .queryParam("template", "true"))
+                            .queryParam("template", "true")
+                            .queryParam("templateId", "3")) // this should be ignored
                     .andExpect(status().isOk())
                     .andExpect(result -> assertEquals(jsonGroceryList.write(newList).getJson(), result.getResponse().getContentAsString()));
+        }
+
+        @Test
+        void testCreateListWithTemplateSuccess() throws Exception {
+            GroceryItem item = new GroceryItem("apple");
+
+            GroceryList newList = new GroceryList();
+            newList.setName("name");
+            newList.setTemplate(false);
+            newList.addItem(item);
+            ReflectionTestUtils.setField(newList, "id", 1L);
+
+            // getPrinciple() is stubbed to return "username"
+            when(groceryService.createNewList(newList.getName(), "username", 3)).thenReturn(newList);
+
+            mvc.perform(post("/api/create-list")
+                            .queryParam("name", "name")
+                            .queryParam("templateId", "3")) // this should be ignored
+                    .andExpect(status().isOk())
+                    .andExpect(result -> assertEquals(jsonGroceryList.write(newList).getJson(), result.getResponse().getContentAsString()));
+        }
+
+        @Test
+        void testCreateListWithTemplateNotFound() throws Exception {
+            when(groceryService.createNewList(anyString(), anyString(), anyLong())).thenThrow(ResourceNotFoundException.class);
+
+            mvc.perform(post("/api/create-list")
+                            .queryParam("name", "name")
+                            .queryParam("templateId", "3")) // this should be ignored
+                    .andExpect(status().isNotFound())
+                    .andExpect(result -> assertTrue(result.getResolvedException() instanceof
+                            ResourceNotFoundException));
         }
 
         @Test


### PR DESCRIPTION
`api/create-list` now takes an optional query parameter `templateId`. If provided, the new grocery list will be initialized with items from the template corresponding to that ID. 

Note that marking a grocery list as a template and initializing with a template are mutually exclusive, with the template marking having precedence. This means that if the `template` parameter is provided as `true`, the grocery list will not be initialized with an existing template, regardless of if `templateId` is provided.

If the provided `templateId` does not correspond to a template the user owns, a 404 error will be returned, with an appropriate message.